### PR TITLE
Build config changes

### DIFF
--- a/snake-kotlinjs/build.gradle
+++ b/snake-kotlinjs/build.gradle
@@ -18,6 +18,10 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-js:$kotlin_version"
 }
 
+compileKotlin2Js {
+    kotlinOptions.sourceMap = true
+}
+
 task assembleWeb(type: Sync) {
     configurations.compile.each { File file ->
         from(zipTree(file.absolutePath), {

--- a/snake-kotlinjs/build.gradle
+++ b/snake-kotlinjs/build.gradle
@@ -9,6 +9,7 @@ buildscript {
 }
 
 apply plugin: 'kotlin2js'
+apply plugin: 'kotlin-dce-js'
 
 repositories {
     mavenCentral()
@@ -18,28 +19,17 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-js:$kotlin_version"
 }
 
+def outDir = "${projectDir}/web"
+
+clean.doFirst {
+    delete outDir
+}
+
 compileKotlin2Js {
     kotlinOptions.sourceMap = true
 }
 
-task assembleWeb(type: Sync) {
-    configurations.compile.each { File file ->
-        from(zipTree(file.absolutePath), {
-            includeEmptyDirs = false
-            include { fileTreeElement ->
-                def path = fileTreeElement.path
-                path.endsWith(".js") &&
-                    (
-                        path.startsWith("META-INF/resources/") ||
-                        !path.startsWith("META-INF/")
-                    )
-            }
-        })
-    }
-    from compileKotlin2Js.destinationDir
-    into "${projectDir}/web"
-
-    dependsOn classes
+runDceKotlinJs {
+    dceOptions.outputDirectory = outDir
+    dceOptions.devMode = false
 }
-
-assemble.dependsOn assembleWeb


### PR DESCRIPTION
With source maps enabled one can debug using firefox or chromium :
![breakpoint](https://user-images.githubusercontent.com/35990632/68494051-a310af00-0245-11ea-91b5-1eb4c885b7d6.png)

After enabling dead code elimination (tree shaking) : 
```
:~/dev/public/snake/snake-kotlinjs$ ll -ogh ./web/kotlin.js 
-rw-r--r-- 1 2.0M Nov  8 15:33 ./web/kotlin.js

:~/dev/public/snake/snake-kotlinjs$ ll -ogh ./web/kotlin.js
-rw-r--r-- 1 192K Nov  8 15:52 ./web/kotlin.js
```